### PR TITLE
Fixed CSS parsing warning

### DIFF
--- a/Code/Glitchy/SD Card/style.css
+++ b/Code/Glitchy/SD Card/style.css
@@ -54,7 +54,7 @@ html {
    /*.button:hover {background-color: #0f8b8d}*/
    .button:active {
      background-color: #0f8b8d;
-     box-shadow: 2 2px #CDCDCD;
+     box-shadow: 2px 2px 12px 1px #CDCDCD;
      transform: translateY(2px);
    }
    .state {


### PR DESCRIPTION
Drop shadow on button apparently had a syntax error.